### PR TITLE
[#51] - Add support to turn off user fetch request

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,26 @@ Vue.use(require('vue-auth'), {
 });
 ~~~
 
+### User Fetching
+
+By default, user fetch request is happening after every login. This is a useful shortcut, but sometimes we don't need this functionality.
+
+We can pass the `fetchData` option to control this behaviour.
+
+~~~
+Vue.use(require('@websanova/vue-auth'), {
+  notFoundRedirect: '/',
+  rolesVar: 'user_permissions',
+  fetchData: null
+})
+~~~
+
+If you pass a falsy value for `fetchData`, automatic user fetching will not happen.
+
+If you don't pass the `fetchData` option, the plugin will do the user fetching with default parameters.
+
+If you pass a custom object for `fetchData`, the plugin will use that configuration when fetching the user. Make sure that you provide an config object that has `url` and `method` properties in this case.
+
 
 
 ## Authentication

--- a/dist/vue-auth.min.js
+++ b/dist/vue-auth.min.js
@@ -65,7 +65,7 @@
 
 	    return function install(Vue, options) {
 	        var auth,
-	            driver = __webpack_require__(42);
+	            driver = __webpack_require__(79);
 
 	        driver.Vue = Vue;
 
@@ -577,8 +577,8 @@
 	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 	var __utils = __webpack_require__(39),
-	    __token = __webpack_require__(40),
-	    __cookie = __webpack_require__(41);
+	    __token = __webpack_require__(77),
+	    __cookie = __webpack_require__(78);
 
 	module.exports = function () {
 
@@ -609,7 +609,7 @@
 
 	    function _routerBeforeEach(cb) {
 
-	        if (!this.watch.loaded && __token.get.call(this)) {
+	        if (this.options.tokenExpired.call(this)) {
 	            this.options.refreshPerform.call(this, {});
 	        }
 
@@ -623,28 +623,34 @@
 	            }
 
 	            this.watch.authenticated = false;
-	            this.options.fetchPerform.call(this, { success: cb, error: cb });
+	            if (this.options.fetchData) {
+	                this.options.fetchPerform.call(this, { success: cb, error: cb });
+	            } else {
+	                this.watch.data = {};
+	                _setLoggedInState.call(this);
+	                cb.call(this);
+	            }
 	        } else {
 	            this.watch.loaded = true;
 	            return cb.call(this);
 	        }
 	    }
 
-	    function _transitionEach(routeAuth, next) {
+	    function _transitionEach(routeAuth, cb) {
 	        routeAuth = __utils.toArray(routeAuth);
 
 	        if (routeAuth && (routeAuth === true || routeAuth.constructor === Array)) {
 	            if (!this.check()) {
-	                this.options._routerReplace.call(this, this.options.authRedirect);
-	            } else if (routeAuth.constructor === Array && !__utils.compare(routeAuth, __utils.toArray(this.watch.data[this.options.rolesVar]))) {
-	                this.options._routerReplace.call(this, this.options.forbiddenRedirect);
+	                cb.call(this, this.options.authRedirect);
+	            } else if (routeAuth.constructor === Array && !__utils.compare(routeAuth, this.watch.data[this.options.rolesVar])) {
+	                cb.call(this, this.options.forbiddenRedirect);
 	            } else {
-	                return next();
+	                return cb();
 	            }
 	        } else if (routeAuth === false && this.check()) {
-	            this.options._routerReplace.call(this, this.options.notFoundRedirect);
+	            cb.call(this, this.options.notFoundRedirect);
 	        } else {
-	            return next();
+	            return cb();
 	        }
 	    }
 
@@ -652,34 +658,23 @@
 	        var token = __token.get.call(this);
 
 	        if (token) {
-	            if (this.options.authType === 'bearer') {
-	                this.options._setHeaders.call(this, req, {
-	                    authorization: 'Bearer: ' + token
-	                });
-	            } else if (this.options.authType === 'basic') {
-	                this.options._setHeaders.call(this, req, {
-	                    authorization: token
-	                });
-	            }
+	            this.options[this.options.authType + 'Auth'].request.call(this, req, token);
 	        }
 
 	        return req;
 	    }
 
 	    function _responseIntercept(res) {
-	        var headers = this.options._getHeaders.call(this, res),
-	            httpData = this.options._httpData.call(this, res);
-
-	        if (headers.token) {
-	            __token.set.call(this, null, headers.token);
-	        }
-
-	        if (httpData[this.options.tokenVar]) {
-	            __token.set.call(this, null, httpData[this.options.tokenVar]);
-	        }
+	        var token;
 
 	        if (this.options._invalidToken) {
 	            this.options._invalidToken.call(this, res);
+	        }
+
+	        token = this.options[this.options.authType + 'Auth'].response.call(this, res);
+
+	        if (token) {
+	            __token.set.call(this, null, token);
 	        }
 	    }
 
@@ -699,6 +694,10 @@
 	        return false;
 	    }
 
+	    function _tokenExpired() {
+	        return !this.watch.loaded && __token.get.call(this);
+	    }
+
 	    function _cookieDomain() {
 	        return window.location.hostname;
 	    }
@@ -707,6 +706,11 @@
 	        var port = window.location.port;
 
 	        return window.location.protocol + '//' + window.location.hostname + (port ? ':' + port : '');
+	    }
+
+	    function _setLoggedInState() {
+	        this.watch.authenticated = true;
+	        this.watch.loaded = true;
 	    }
 
 	    function _fetchPerform(data) {
@@ -725,9 +729,8 @@
 	    }
 
 	    function _fetchProcess(res, data) {
-	        this.watch.authenticated = true;
 	        this.watch.data = this.options.parseUserData.call(this, this.options._httpData.call(this, res));
-	        this.watch.loaded = true;
+	        _setLoggedInState.call(this);
 
 	        if (data.success) {
 	            data.success.call(this, res);
@@ -775,17 +778,24 @@
 
 	        this.authenticated = null;
 
-	        this.options.fetchPerform.call(this, {
-	            success: function success() {
-	                if (data.success) {
-	                    data.success.call(this, res);
-	                }
+	        if (this.options.fetchData) {
+	            this.options.fetchPerform.call(this, {
+	                success: _afterLoginProcessed.bind(this, data)
+	            });
+	        } else {
+	            this.watch.data = {};
+	            _afterLoginProcessed.call(this, data);
+	        }
+	    }
 
-	                if (data.redirect && _this.options.check.call(_this)) {
-	                    _this.options._routerGo.call(_this, data.redirect);
-	                }
-	            }
-	        });
+	    function _afterLoginProcessed(data) {
+	        if (data.success) {
+	            data.success.call(this, res);
+	        }
+
+	        if (data.redirect && this.options.check.call(this)) {
+	            this.options._routerGo.call(this, data.redirect);
+	        }
 	    }
 
 	    function _logoutPerform(data) {
@@ -881,25 +891,26 @@
 	    }
 
 	    function _oauth2Perform(data) {
-	        var state,
-	            params = '';
+	        var state = {},
+	            params = '',
+	            query = {};
 
-	        console.log(data);
-
-	        if (data.code) {
+	        if (data.code === true) {
 	            data = __utils.extend(this.options[data.provider + 'Data'], [data]);
 
 	            try {
-	                state = JSON.parse(decodeURIComponent(this.options._getQuery.call(this)));
+	                if (data.query.state) {
+	                    state = JSON.parse(decodeURIComponent(data.query.state));
+	                }
 	            } catch (e) {
 	                console.error('vue-auth:error There was an issue retrieving the state data.');
 	                state = {};
 	            }
 
-	            console.log(data);
-	            console.log(state);
+	            data.rememberMe = state.rememberMe === true;
+	            data.state = state;
 
-	            // _login.call(this, this.getOption(type + 'Url'), data, state.rememberMe, state.redirect, options);
+	            this.options.loginPerform.call(this, data);
 	        } else {
 	            data = __utils.extend(this.options[data.provider + 'Oauth2Data'], [data]);
 
@@ -908,26 +919,19 @@
 	            data.state = data.state || {};
 	            data.state.rememberMe = data.rememberMe === true;
 
-	            console.log(data);
-
-	            params = '?client_id=' + data.appId + '&redirect_uri=' + data.redirect + '&scope=' + data.scope + '&response_type=code&state=' + encodeURIComponent((0, _stringify2.default)(data.state));
+	            params = '?client_id=' + data.clientId + '&redirect_uri=' + data.redirect + '&scope=' + data.scope + '&response_type=code&state=' + encodeURIComponent((0, _stringify2.default)(data.state));
 
 	            window.location = data.url + params;
 	        }
 	    }
 
-	    function _oauth2Process() {}
-
 	    var defaultOptions = {
 
 	        // Variables
 
-	        tokenVar: 'token',
-	        tokenName: 'auth-token',
-	        tokenHeader: 'Authorization',
-
 	        authType: 'bearer',
 	        rolesVar: 'roles',
+	        tokenName: 'auth-token',
 
 	        // Objects
 
@@ -940,7 +944,7 @@
 	        logoutData: { url: 'auth/logout', method: 'POST', redirect: '/', makeRequest: false },
 	        oauth1Data: { url: 'auth/login', method: 'POST' },
 	        fetchData: { url: 'auth/user', method: 'GET' },
-	        refreshData: { url: 'auth/refresh', method: 'GET', atInit: true },
+	        refreshData: { url: 'auth/refresh', method: 'GET' },
 	        loginOtherData: { url: 'auth/login-other', method: 'POST', redirect: '/' },
 	        logoutOtherData: { url: 'auth/logout-other', method: 'POST', redirect: '/admin', makeRequest: false },
 
@@ -952,7 +956,7 @@
 	            redirect: function redirect() {
 	                return this.options.getUrl() + '/login/facebook';
 	            },
-	            appId: '',
+	            clientId: '',
 	            scope: 'email'
 	        },
 	        googleOauth2Data: {
@@ -960,7 +964,7 @@
 	            redirect: function redirect() {
 	                return this.options.getUrl() + '/login/google';
 	            },
-	            appId: '',
+	            clientId: '',
 	            scope: 'https://www.googleapis.com/auth/plus.me https://www.googleapis.com/auth/plus.login https://www.googleapis.com/auth/plus.profile.emails.read'
 	        },
 
@@ -969,10 +973,8 @@
 	        getUrl: _getUrl,
 	        cookieDomain: _cookieDomain,
 	        parseUserData: _parseUserData,
+	        tokenExpired: _tokenExpired,
 	        check: _check,
-
-	        // disableOther
-	        // enableOther
 
 	        transitionEach: _transitionEach,
 	        routerBeforeEach: _routerBeforeEach,
@@ -1003,14 +1005,82 @@
 	        logoutOtherProcess: _logoutOtherProcess,
 
 	        oauth2Perform: _oauth2Perform,
-	        oauth2Process: _oauth2Process
+
+	        // Auth drivers
+
+	        bearerAuth: {
+	            request: function request(req, token) {
+	                this.options._setHeaders.call(this, req, { Authorization: 'Bearer ' + token });
+	            },
+
+	            response: function response(res) {
+	                var token = this.options._getHeaders.call(this, res).Authorization;
+
+	                if (token) {
+	                    token = token.split('Bearer ');
+
+	                    return token[token.length > 1 ? 1 : 0];
+	                }
+	            }
+	        },
+
+	        basicAuth: {
+	            request: function request(req, token) {
+	                this.options._setHeaders.call(this, req, { Authorization: token });
+	            },
+
+	            response: function response(res) {
+	                var token = this.options._getHeaders.call(this, res).Authorization;
+
+	                return token;
+	            }
+	        },
+
+	        deviseAuth: {
+	            tokens: ['Token-Type', 'Access-Token', 'Client', 'Uid', 'Expiry'],
+
+	            request: function request(req, token) {
+	                var headers = {},
+	                    tokens = token.split(';');
+
+	                this.options.deviseAuth.tokens.forEach(function (tokenName, index) {
+	                    if (tokens[index]) {
+	                        headers[tokenName] = tokens[index];
+	                    }
+	                });
+
+	                this.options._setHeaders.call(this, req, headers);
+	            },
+
+	            response: function response(res) {
+	                var token = [],
+	                    headers = this.options._getHeaders.call(this, res);
+
+	                if (headers['Access-Token']) {
+	                    this.options.deviseAuth.tokens.forEach(function (tokenName) {
+	                        if (headers[tokenName]) {
+	                            token.push(headers[tokenName]);
+	                        }
+	                    });
+
+	                    return token.join(';');
+	                }
+	            }
+	        }
 	    };
 
 	    function Auth(options, driver) {
+	        var router = options.router,
+	            http = options.http;
+
+	        delete options.http;
+	        delete options.router;
 
 	        this.currentToken = null;
 
 	        this.options = __utils.extend(defaultOptions, [driver || {}, options || {}]);
+	        this.options.router = router;
+	        this.options.http = http;
 
 	        this.watch = this.options._watch.call(this, {
 	            data: null,
@@ -1030,7 +1100,7 @@
 	            this.watch.data = data;
 	        }
 
-	        return this.watch.data;
+	        return this.watch.data || {};
 	    };
 
 	    Auth.prototype.check = function (role) {
@@ -1112,11 +1182,25 @@
 
 /***/ },
 /* 39 */
-/***/ function(module, exports) {
+/***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
 
+	var _typeof2 = __webpack_require__(40);
+
+	var _typeof3 = _interopRequireDefault(_typeof2);
+
+	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
 	module.exports = function () {
+
+	    function isObject(val) {
+	        if (val !== null && (typeof val === 'undefined' ? 'undefined' : (0, _typeof3.default)(val)) === 'object' && val.constructor !== Array) {
+	            return true;
+	        }
+
+	        return false;
+	    }
 
 	    function toArray(val) {
 	        return typeof val === 'string' ? [val] : val;
@@ -1129,12 +1213,20 @@
 	            data = {};
 
 	        for (key in mainObj) {
-	            data[key] = mainObj[key];
+	            if (isObject(mainObj[key])) {
+	                data[key] = extend(mainObj[key], {});
+	            } else {
+	                data[key] = mainObj[key];
+	            }
 	        }
 
 	        for (i = 0, ii = appendObj.length; i < ii; i++) {
 	            for (key in appendObj[i]) {
-	                data[key] = appendObj[i][key];
+	                if (isObject(appendObj[i][key])) {
+	                    data[key] = extend(mainObj[key] || {}, [appendObj[i][key]]);
+	                } else {
+	                    data[key] = appendObj[i][key];
+	                }
 	            }
 	        }
 
@@ -1142,7 +1234,17 @@
 	    }
 
 	    function compare(one, two) {
-	        var i, ii;
+	        var i, ii, key;
+
+	        if ((typeof one === 'undefined' ? 'undefined' : (0, _typeof3.default)(one)) === 'object' && (typeof two === 'undefined' ? 'undefined' : (0, _typeof3.default)(two)) === 'object') {
+	            for (key in one) {
+	                if (compare(one[key], two[key])) {
+	                    return true;
+	                }
+	            }
+
+	            return false;
+	        }
 
 	        one = toArray(one);
 	        two = toArray(two);
@@ -1169,6 +1271,848 @@
 
 /***/ },
 /* 40 */
+/***/ function(module, exports, __webpack_require__) {
+
+	"use strict";
+
+	exports.__esModule = true;
+
+	var _iterator = __webpack_require__(41);
+
+	var _iterator2 = _interopRequireDefault(_iterator);
+
+	var _symbol = __webpack_require__(61);
+
+	var _symbol2 = _interopRequireDefault(_symbol);
+
+	var _typeof = typeof _symbol2.default === "function" && typeof _iterator2.default === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof _symbol2.default === "function" && obj.constructor === _symbol2.default ? "symbol" : typeof obj; };
+
+	function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+	exports.default = typeof _symbol2.default === "function" && _typeof(_iterator2.default) === "symbol" ? function (obj) {
+	  return typeof obj === "undefined" ? "undefined" : _typeof(obj);
+	} : function (obj) {
+	  return obj && typeof _symbol2.default === "function" && obj.constructor === _symbol2.default ? "symbol" : typeof obj === "undefined" ? "undefined" : _typeof(obj);
+	};
+
+/***/ },
+/* 41 */
+/***/ function(module, exports, __webpack_require__) {
+
+	module.exports = { "default": __webpack_require__(42), __esModule: true };
+
+/***/ },
+/* 42 */
+/***/ function(module, exports, __webpack_require__) {
+
+	__webpack_require__(43);
+	__webpack_require__(56);
+	module.exports = __webpack_require__(60).f('iterator');
+
+/***/ },
+/* 43 */
+/***/ function(module, exports, __webpack_require__) {
+
+	'use strict';
+	var $at  = __webpack_require__(44)(true);
+
+	// 21.1.3.27 String.prototype[@@iterator]()
+	__webpack_require__(45)(String, 'String', function(iterated){
+	  this._t = String(iterated); // target
+	  this._i = 0;                // next index
+	// 21.1.5.2.1 %StringIteratorPrototype%.next()
+	}, function(){
+	  var O     = this._t
+	    , index = this._i
+	    , point;
+	  if(index >= O.length)return {value: undefined, done: true};
+	  point = $at(O, index);
+	  this._i += point.length;
+	  return {value: point, done: false};
+	});
+
+/***/ },
+/* 44 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var toInteger = __webpack_require__(30)
+	  , defined   = __webpack_require__(27);
+	// true  -> String#at
+	// false -> String#codePointAt
+	module.exports = function(TO_STRING){
+	  return function(that, pos){
+	    var s = String(defined(that))
+	      , i = toInteger(pos)
+	      , l = s.length
+	      , a, b;
+	    if(i < 0 || i >= l)return TO_STRING ? '' : undefined;
+	    a = s.charCodeAt(i);
+	    return a < 0xd800 || a > 0xdbff || i + 1 === l || (b = s.charCodeAt(i + 1)) < 0xdc00 || b > 0xdfff
+	      ? TO_STRING ? s.charAt(i) : a
+	      : TO_STRING ? s.slice(i, i + 2) : (a - 0xd800 << 10) + (b - 0xdc00) + 0x10000;
+	  };
+	};
+
+/***/ },
+/* 45 */
+/***/ function(module, exports, __webpack_require__) {
+
+	'use strict';
+	var LIBRARY        = __webpack_require__(46)
+	  , $export        = __webpack_require__(5)
+	  , redefine       = __webpack_require__(47)
+	  , hide           = __webpack_require__(10)
+	  , has            = __webpack_require__(23)
+	  , Iterators      = __webpack_require__(48)
+	  , $iterCreate    = __webpack_require__(49)
+	  , setToStringTag = __webpack_require__(52)
+	  , getPrototypeOf = __webpack_require__(54)
+	  , ITERATOR       = __webpack_require__(53)('iterator')
+	  , BUGGY          = !([].keys && 'next' in [].keys()) // Safari has buggy iterators w/o `next`
+	  , FF_ITERATOR    = '@@iterator'
+	  , KEYS           = 'keys'
+	  , VALUES         = 'values';
+
+	var returnThis = function(){ return this; };
+
+	module.exports = function(Base, NAME, Constructor, next, DEFAULT, IS_SET, FORCED){
+	  $iterCreate(Constructor, NAME, next);
+	  var getMethod = function(kind){
+	    if(!BUGGY && kind in proto)return proto[kind];
+	    switch(kind){
+	      case KEYS: return function keys(){ return new Constructor(this, kind); };
+	      case VALUES: return function values(){ return new Constructor(this, kind); };
+	    } return function entries(){ return new Constructor(this, kind); };
+	  };
+	  var TAG        = NAME + ' Iterator'
+	    , DEF_VALUES = DEFAULT == VALUES
+	    , VALUES_BUG = false
+	    , proto      = Base.prototype
+	    , $native    = proto[ITERATOR] || proto[FF_ITERATOR] || DEFAULT && proto[DEFAULT]
+	    , $default   = $native || getMethod(DEFAULT)
+	    , $entries   = DEFAULT ? !DEF_VALUES ? $default : getMethod('entries') : undefined
+	    , $anyNative = NAME == 'Array' ? proto.entries || $native : $native
+	    , methods, key, IteratorPrototype;
+	  // Fix native
+	  if($anyNative){
+	    IteratorPrototype = getPrototypeOf($anyNative.call(new Base));
+	    if(IteratorPrototype !== Object.prototype){
+	      // Set @@toStringTag to native iterators
+	      setToStringTag(IteratorPrototype, TAG, true);
+	      // fix for some old engines
+	      if(!LIBRARY && !has(IteratorPrototype, ITERATOR))hide(IteratorPrototype, ITERATOR, returnThis);
+	    }
+	  }
+	  // fix Array#{values, @@iterator}.name in V8 / FF
+	  if(DEF_VALUES && $native && $native.name !== VALUES){
+	    VALUES_BUG = true;
+	    $default = function values(){ return $native.call(this); };
+	  }
+	  // Define iterator
+	  if((!LIBRARY || FORCED) && (BUGGY || VALUES_BUG || !proto[ITERATOR])){
+	    hide(proto, ITERATOR, $default);
+	  }
+	  // Plug for library
+	  Iterators[NAME] = $default;
+	  Iterators[TAG]  = returnThis;
+	  if(DEFAULT){
+	    methods = {
+	      values:  DEF_VALUES ? $default : getMethod(VALUES),
+	      keys:    IS_SET     ? $default : getMethod(KEYS),
+	      entries: $entries
+	    };
+	    if(FORCED)for(key in methods){
+	      if(!(key in proto))redefine(proto, key, methods[key]);
+	    } else $export($export.P + $export.F * (BUGGY || VALUES_BUG), NAME, methods);
+	  }
+	  return methods;
+	};
+
+/***/ },
+/* 46 */
+/***/ function(module, exports) {
+
+	module.exports = true;
+
+/***/ },
+/* 47 */
+/***/ function(module, exports, __webpack_require__) {
+
+	module.exports = __webpack_require__(10);
+
+/***/ },
+/* 48 */
+/***/ function(module, exports) {
+
+	module.exports = {};
+
+/***/ },
+/* 49 */
+/***/ function(module, exports, __webpack_require__) {
+
+	'use strict';
+	var create         = __webpack_require__(50)
+	  , descriptor     = __webpack_require__(19)
+	  , setToStringTag = __webpack_require__(52)
+	  , IteratorPrototype = {};
+
+	// 25.1.2.1.1 %IteratorPrototype%[@@iterator]()
+	__webpack_require__(10)(IteratorPrototype, __webpack_require__(53)('iterator'), function(){ return this; });
+
+	module.exports = function(Constructor, NAME, next){
+	  Constructor.prototype = create(IteratorPrototype, {next: descriptor(1, next)});
+	  setToStringTag(Constructor, NAME + ' Iterator');
+	};
+
+/***/ },
+/* 50 */
+/***/ function(module, exports, __webpack_require__) {
+
+	// 19.1.2.2 / 15.2.3.5 Object.create(O [, Properties])
+	var anObject    = __webpack_require__(12)
+	  , dPs         = __webpack_require__(20)
+	  , enumBugKeys = __webpack_require__(35)
+	  , IE_PROTO    = __webpack_require__(32)('IE_PROTO')
+	  , Empty       = function(){ /* empty */ }
+	  , PROTOTYPE   = 'prototype';
+
+	// Create object with fake `null` prototype: use iframe Object with cleared prototype
+	var createDict = function(){
+	  // Thrash, waste and sodomy: IE GC bug
+	  var iframe = __webpack_require__(17)('iframe')
+	    , i      = enumBugKeys.length
+	    , lt     = '<'
+	    , gt     = '>'
+	    , iframeDocument;
+	  iframe.style.display = 'none';
+	  __webpack_require__(51).appendChild(iframe);
+	  iframe.src = 'javascript:'; // eslint-disable-line no-script-url
+	  // createDict = iframe.contentWindow.Object;
+	  // html.removeChild(iframe);
+	  iframeDocument = iframe.contentWindow.document;
+	  iframeDocument.open();
+	  iframeDocument.write(lt + 'script' + gt + 'document.F=Object' + lt + '/script' + gt);
+	  iframeDocument.close();
+	  createDict = iframeDocument.F;
+	  while(i--)delete createDict[PROTOTYPE][enumBugKeys[i]];
+	  return createDict();
+	};
+
+	module.exports = Object.create || function create(O, Properties){
+	  var result;
+	  if(O !== null){
+	    Empty[PROTOTYPE] = anObject(O);
+	    result = new Empty;
+	    Empty[PROTOTYPE] = null;
+	    // add "__proto__" for Object.getPrototypeOf polyfill
+	    result[IE_PROTO] = O;
+	  } else result = createDict();
+	  return Properties === undefined ? result : dPs(result, Properties);
+	};
+
+
+/***/ },
+/* 51 */
+/***/ function(module, exports, __webpack_require__) {
+
+	module.exports = __webpack_require__(6).document && document.documentElement;
+
+/***/ },
+/* 52 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var def = __webpack_require__(11).f
+	  , has = __webpack_require__(23)
+	  , TAG = __webpack_require__(53)('toStringTag');
+
+	module.exports = function(it, tag, stat){
+	  if(it && !has(it = stat ? it : it.prototype, TAG))def(it, TAG, {configurable: true, value: tag});
+	};
+
+/***/ },
+/* 53 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var store      = __webpack_require__(33)('wks')
+	  , uid        = __webpack_require__(34)
+	  , Symbol     = __webpack_require__(6).Symbol
+	  , USE_SYMBOL = typeof Symbol == 'function';
+
+	var $exports = module.exports = function(name){
+	  return store[name] || (store[name] =
+	    USE_SYMBOL && Symbol[name] || (USE_SYMBOL ? Symbol : uid)('Symbol.' + name));
+	};
+
+	$exports.store = store;
+
+/***/ },
+/* 54 */
+/***/ function(module, exports, __webpack_require__) {
+
+	// 19.1.2.9 / 15.2.3.2 Object.getPrototypeOf(O)
+	var has         = __webpack_require__(23)
+	  , toObject    = __webpack_require__(55)
+	  , IE_PROTO    = __webpack_require__(32)('IE_PROTO')
+	  , ObjectProto = Object.prototype;
+
+	module.exports = Object.getPrototypeOf || function(O){
+	  O = toObject(O);
+	  if(has(O, IE_PROTO))return O[IE_PROTO];
+	  if(typeof O.constructor == 'function' && O instanceof O.constructor){
+	    return O.constructor.prototype;
+	  } return O instanceof Object ? ObjectProto : null;
+	};
+
+/***/ },
+/* 55 */
+/***/ function(module, exports, __webpack_require__) {
+
+	// 7.1.13 ToObject(argument)
+	var defined = __webpack_require__(27);
+	module.exports = function(it){
+	  return Object(defined(it));
+	};
+
+/***/ },
+/* 56 */
+/***/ function(module, exports, __webpack_require__) {
+
+	__webpack_require__(57);
+	var global        = __webpack_require__(6)
+	  , hide          = __webpack_require__(10)
+	  , Iterators     = __webpack_require__(48)
+	  , TO_STRING_TAG = __webpack_require__(53)('toStringTag');
+
+	for(var collections = ['NodeList', 'DOMTokenList', 'MediaList', 'StyleSheetList', 'CSSRuleList'], i = 0; i < 5; i++){
+	  var NAME       = collections[i]
+	    , Collection = global[NAME]
+	    , proto      = Collection && Collection.prototype;
+	  if(proto && !proto[TO_STRING_TAG])hide(proto, TO_STRING_TAG, NAME);
+	  Iterators[NAME] = Iterators.Array;
+	}
+
+/***/ },
+/* 57 */
+/***/ function(module, exports, __webpack_require__) {
+
+	'use strict';
+	var addToUnscopables = __webpack_require__(58)
+	  , step             = __webpack_require__(59)
+	  , Iterators        = __webpack_require__(48)
+	  , toIObject        = __webpack_require__(24);
+
+	// 22.1.3.4 Array.prototype.entries()
+	// 22.1.3.13 Array.prototype.keys()
+	// 22.1.3.29 Array.prototype.values()
+	// 22.1.3.30 Array.prototype[@@iterator]()
+	module.exports = __webpack_require__(45)(Array, 'Array', function(iterated, kind){
+	  this._t = toIObject(iterated); // target
+	  this._i = 0;                   // next index
+	  this._k = kind;                // kind
+	// 22.1.5.2.1 %ArrayIteratorPrototype%.next()
+	}, function(){
+	  var O     = this._t
+	    , kind  = this._k
+	    , index = this._i++;
+	  if(!O || index >= O.length){
+	    this._t = undefined;
+	    return step(1);
+	  }
+	  if(kind == 'keys'  )return step(0, index);
+	  if(kind == 'values')return step(0, O[index]);
+	  return step(0, [index, O[index]]);
+	}, 'values');
+
+	// argumentsList[@@iterator] is %ArrayProto_values% (9.4.4.6, 9.4.4.7)
+	Iterators.Arguments = Iterators.Array;
+
+	addToUnscopables('keys');
+	addToUnscopables('values');
+	addToUnscopables('entries');
+
+/***/ },
+/* 58 */
+/***/ function(module, exports) {
+
+	module.exports = function(){ /* empty */ };
+
+/***/ },
+/* 59 */
+/***/ function(module, exports) {
+
+	module.exports = function(done, value){
+	  return {value: value, done: !!done};
+	};
+
+/***/ },
+/* 60 */
+/***/ function(module, exports, __webpack_require__) {
+
+	exports.f = __webpack_require__(53);
+
+/***/ },
+/* 61 */
+/***/ function(module, exports, __webpack_require__) {
+
+	module.exports = { "default": __webpack_require__(62), __esModule: true };
+
+/***/ },
+/* 62 */
+/***/ function(module, exports, __webpack_require__) {
+
+	__webpack_require__(63);
+	__webpack_require__(74);
+	__webpack_require__(75);
+	__webpack_require__(76);
+	module.exports = __webpack_require__(7).Symbol;
+
+/***/ },
+/* 63 */
+/***/ function(module, exports, __webpack_require__) {
+
+	'use strict';
+	// ECMAScript 6 symbols shim
+	var global         = __webpack_require__(6)
+	  , has            = __webpack_require__(23)
+	  , DESCRIPTORS    = __webpack_require__(15)
+	  , $export        = __webpack_require__(5)
+	  , redefine       = __webpack_require__(47)
+	  , META           = __webpack_require__(64).KEY
+	  , $fails         = __webpack_require__(16)
+	  , shared         = __webpack_require__(33)
+	  , setToStringTag = __webpack_require__(52)
+	  , uid            = __webpack_require__(34)
+	  , wks            = __webpack_require__(53)
+	  , wksExt         = __webpack_require__(60)
+	  , wksDefine      = __webpack_require__(65)
+	  , keyOf          = __webpack_require__(66)
+	  , enumKeys       = __webpack_require__(67)
+	  , isArray        = __webpack_require__(70)
+	  , anObject       = __webpack_require__(12)
+	  , toIObject      = __webpack_require__(24)
+	  , toPrimitive    = __webpack_require__(18)
+	  , createDesc     = __webpack_require__(19)
+	  , _create        = __webpack_require__(50)
+	  , gOPNExt        = __webpack_require__(71)
+	  , $GOPD          = __webpack_require__(73)
+	  , $DP            = __webpack_require__(11)
+	  , $keys          = __webpack_require__(21)
+	  , gOPD           = $GOPD.f
+	  , dP             = $DP.f
+	  , gOPN           = gOPNExt.f
+	  , $Symbol        = global.Symbol
+	  , $JSON          = global.JSON
+	  , _stringify     = $JSON && $JSON.stringify
+	  , PROTOTYPE      = 'prototype'
+	  , HIDDEN         = wks('_hidden')
+	  , TO_PRIMITIVE   = wks('toPrimitive')
+	  , isEnum         = {}.propertyIsEnumerable
+	  , SymbolRegistry = shared('symbol-registry')
+	  , AllSymbols     = shared('symbols')
+	  , OPSymbols      = shared('op-symbols')
+	  , ObjectProto    = Object[PROTOTYPE]
+	  , USE_NATIVE     = typeof $Symbol == 'function'
+	  , QObject        = global.QObject;
+	// Don't use setters in Qt Script, https://github.com/zloirock/core-js/issues/173
+	var setter = !QObject || !QObject[PROTOTYPE] || !QObject[PROTOTYPE].findChild;
+
+	// fallback for old Android, https://code.google.com/p/v8/issues/detail?id=687
+	var setSymbolDesc = DESCRIPTORS && $fails(function(){
+	  return _create(dP({}, 'a', {
+	    get: function(){ return dP(this, 'a', {value: 7}).a; }
+	  })).a != 7;
+	}) ? function(it, key, D){
+	  var protoDesc = gOPD(ObjectProto, key);
+	  if(protoDesc)delete ObjectProto[key];
+	  dP(it, key, D);
+	  if(protoDesc && it !== ObjectProto)dP(ObjectProto, key, protoDesc);
+	} : dP;
+
+	var wrap = function(tag){
+	  var sym = AllSymbols[tag] = _create($Symbol[PROTOTYPE]);
+	  sym._k = tag;
+	  return sym;
+	};
+
+	var isSymbol = USE_NATIVE && typeof $Symbol.iterator == 'symbol' ? function(it){
+	  return typeof it == 'symbol';
+	} : function(it){
+	  return it instanceof $Symbol;
+	};
+
+	var $defineProperty = function defineProperty(it, key, D){
+	  if(it === ObjectProto)$defineProperty(OPSymbols, key, D);
+	  anObject(it);
+	  key = toPrimitive(key, true);
+	  anObject(D);
+	  if(has(AllSymbols, key)){
+	    if(!D.enumerable){
+	      if(!has(it, HIDDEN))dP(it, HIDDEN, createDesc(1, {}));
+	      it[HIDDEN][key] = true;
+	    } else {
+	      if(has(it, HIDDEN) && it[HIDDEN][key])it[HIDDEN][key] = false;
+	      D = _create(D, {enumerable: createDesc(0, false)});
+	    } return setSymbolDesc(it, key, D);
+	  } return dP(it, key, D);
+	};
+	var $defineProperties = function defineProperties(it, P){
+	  anObject(it);
+	  var keys = enumKeys(P = toIObject(P))
+	    , i    = 0
+	    , l = keys.length
+	    , key;
+	  while(l > i)$defineProperty(it, key = keys[i++], P[key]);
+	  return it;
+	};
+	var $create = function create(it, P){
+	  return P === undefined ? _create(it) : $defineProperties(_create(it), P);
+	};
+	var $propertyIsEnumerable = function propertyIsEnumerable(key){
+	  var E = isEnum.call(this, key = toPrimitive(key, true));
+	  if(this === ObjectProto && has(AllSymbols, key) && !has(OPSymbols, key))return false;
+	  return E || !has(this, key) || !has(AllSymbols, key) || has(this, HIDDEN) && this[HIDDEN][key] ? E : true;
+	};
+	var $getOwnPropertyDescriptor = function getOwnPropertyDescriptor(it, key){
+	  it  = toIObject(it);
+	  key = toPrimitive(key, true);
+	  if(it === ObjectProto && has(AllSymbols, key) && !has(OPSymbols, key))return;
+	  var D = gOPD(it, key);
+	  if(D && has(AllSymbols, key) && !(has(it, HIDDEN) && it[HIDDEN][key]))D.enumerable = true;
+	  return D;
+	};
+	var $getOwnPropertyNames = function getOwnPropertyNames(it){
+	  var names  = gOPN(toIObject(it))
+	    , result = []
+	    , i      = 0
+	    , key;
+	  while(names.length > i){
+	    if(!has(AllSymbols, key = names[i++]) && key != HIDDEN && key != META)result.push(key);
+	  } return result;
+	};
+	var $getOwnPropertySymbols = function getOwnPropertySymbols(it){
+	  var IS_OP  = it === ObjectProto
+	    , names  = gOPN(IS_OP ? OPSymbols : toIObject(it))
+	    , result = []
+	    , i      = 0
+	    , key;
+	  while(names.length > i){
+	    if(has(AllSymbols, key = names[i++]) && (IS_OP ? has(ObjectProto, key) : true))result.push(AllSymbols[key]);
+	  } return result;
+	};
+
+	// 19.4.1.1 Symbol([description])
+	if(!USE_NATIVE){
+	  $Symbol = function Symbol(){
+	    if(this instanceof $Symbol)throw TypeError('Symbol is not a constructor!');
+	    var tag = uid(arguments.length > 0 ? arguments[0] : undefined);
+	    var $set = function(value){
+	      if(this === ObjectProto)$set.call(OPSymbols, value);
+	      if(has(this, HIDDEN) && has(this[HIDDEN], tag))this[HIDDEN][tag] = false;
+	      setSymbolDesc(this, tag, createDesc(1, value));
+	    };
+	    if(DESCRIPTORS && setter)setSymbolDesc(ObjectProto, tag, {configurable: true, set: $set});
+	    return wrap(tag);
+	  };
+	  redefine($Symbol[PROTOTYPE], 'toString', function toString(){
+	    return this._k;
+	  });
+
+	  $GOPD.f = $getOwnPropertyDescriptor;
+	  $DP.f   = $defineProperty;
+	  __webpack_require__(72).f = gOPNExt.f = $getOwnPropertyNames;
+	  __webpack_require__(69).f  = $propertyIsEnumerable;
+	  __webpack_require__(68).f = $getOwnPropertySymbols;
+
+	  if(DESCRIPTORS && !__webpack_require__(46)){
+	    redefine(ObjectProto, 'propertyIsEnumerable', $propertyIsEnumerable, true);
+	  }
+
+	  wksExt.f = function(name){
+	    return wrap(wks(name));
+	  }
+	}
+
+	$export($export.G + $export.W + $export.F * !USE_NATIVE, {Symbol: $Symbol});
+
+	for(var symbols = (
+	  // 19.4.2.2, 19.4.2.3, 19.4.2.4, 19.4.2.6, 19.4.2.8, 19.4.2.9, 19.4.2.10, 19.4.2.11, 19.4.2.12, 19.4.2.13, 19.4.2.14
+	  'hasInstance,isConcatSpreadable,iterator,match,replace,search,species,split,toPrimitive,toStringTag,unscopables'
+	).split(','), i = 0; symbols.length > i; )wks(symbols[i++]);
+
+	for(var symbols = $keys(wks.store), i = 0; symbols.length > i; )wksDefine(symbols[i++]);
+
+	$export($export.S + $export.F * !USE_NATIVE, 'Symbol', {
+	  // 19.4.2.1 Symbol.for(key)
+	  'for': function(key){
+	    return has(SymbolRegistry, key += '')
+	      ? SymbolRegistry[key]
+	      : SymbolRegistry[key] = $Symbol(key);
+	  },
+	  // 19.4.2.5 Symbol.keyFor(sym)
+	  keyFor: function keyFor(key){
+	    if(isSymbol(key))return keyOf(SymbolRegistry, key);
+	    throw TypeError(key + ' is not a symbol!');
+	  },
+	  useSetter: function(){ setter = true; },
+	  useSimple: function(){ setter = false; }
+	});
+
+	$export($export.S + $export.F * !USE_NATIVE, 'Object', {
+	  // 19.1.2.2 Object.create(O [, Properties])
+	  create: $create,
+	  // 19.1.2.4 Object.defineProperty(O, P, Attributes)
+	  defineProperty: $defineProperty,
+	  // 19.1.2.3 Object.defineProperties(O, Properties)
+	  defineProperties: $defineProperties,
+	  // 19.1.2.6 Object.getOwnPropertyDescriptor(O, P)
+	  getOwnPropertyDescriptor: $getOwnPropertyDescriptor,
+	  // 19.1.2.7 Object.getOwnPropertyNames(O)
+	  getOwnPropertyNames: $getOwnPropertyNames,
+	  // 19.1.2.8 Object.getOwnPropertySymbols(O)
+	  getOwnPropertySymbols: $getOwnPropertySymbols
+	});
+
+	// 24.3.2 JSON.stringify(value [, replacer [, space]])
+	$JSON && $export($export.S + $export.F * (!USE_NATIVE || $fails(function(){
+	  var S = $Symbol();
+	  // MS Edge converts symbol values to JSON as {}
+	  // WebKit converts symbol values to JSON as null
+	  // V8 throws on boxed symbols
+	  return _stringify([S]) != '[null]' || _stringify({a: S}) != '{}' || _stringify(Object(S)) != '{}';
+	})), 'JSON', {
+	  stringify: function stringify(it){
+	    if(it === undefined || isSymbol(it))return; // IE8 returns string on undefined
+	    var args = [it]
+	      , i    = 1
+	      , replacer, $replacer;
+	    while(arguments.length > i)args.push(arguments[i++]);
+	    replacer = args[1];
+	    if(typeof replacer == 'function')$replacer = replacer;
+	    if($replacer || !isArray(replacer))replacer = function(key, value){
+	      if($replacer)value = $replacer.call(this, key, value);
+	      if(!isSymbol(value))return value;
+	    };
+	    args[1] = replacer;
+	    return _stringify.apply($JSON, args);
+	  }
+	});
+
+	// 19.4.3.4 Symbol.prototype[@@toPrimitive](hint)
+	$Symbol[PROTOTYPE][TO_PRIMITIVE] || __webpack_require__(10)($Symbol[PROTOTYPE], TO_PRIMITIVE, $Symbol[PROTOTYPE].valueOf);
+	// 19.4.3.5 Symbol.prototype[@@toStringTag]
+	setToStringTag($Symbol, 'Symbol');
+	// 20.2.1.9 Math[@@toStringTag]
+	setToStringTag(Math, 'Math', true);
+	// 24.3.3 JSON[@@toStringTag]
+	setToStringTag(global.JSON, 'JSON', true);
+
+/***/ },
+/* 64 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var META     = __webpack_require__(34)('meta')
+	  , isObject = __webpack_require__(13)
+	  , has      = __webpack_require__(23)
+	  , setDesc  = __webpack_require__(11).f
+	  , id       = 0;
+	var isExtensible = Object.isExtensible || function(){
+	  return true;
+	};
+	var FREEZE = !__webpack_require__(16)(function(){
+	  return isExtensible(Object.preventExtensions({}));
+	});
+	var setMeta = function(it){
+	  setDesc(it, META, {value: {
+	    i: 'O' + ++id, // object ID
+	    w: {}          // weak collections IDs
+	  }});
+	};
+	var fastKey = function(it, create){
+	  // return primitive with prefix
+	  if(!isObject(it))return typeof it == 'symbol' ? it : (typeof it == 'string' ? 'S' : 'P') + it;
+	  if(!has(it, META)){
+	    // can't set metadata to uncaught frozen object
+	    if(!isExtensible(it))return 'F';
+	    // not necessary to add metadata
+	    if(!create)return 'E';
+	    // add missing metadata
+	    setMeta(it);
+	  // return object ID
+	  } return it[META].i;
+	};
+	var getWeak = function(it, create){
+	  if(!has(it, META)){
+	    // can't set metadata to uncaught frozen object
+	    if(!isExtensible(it))return true;
+	    // not necessary to add metadata
+	    if(!create)return false;
+	    // add missing metadata
+	    setMeta(it);
+	  // return hash weak collections IDs
+	  } return it[META].w;
+	};
+	// add metadata on freeze-family methods calling
+	var onFreeze = function(it){
+	  if(FREEZE && meta.NEED && isExtensible(it) && !has(it, META))setMeta(it);
+	  return it;
+	};
+	var meta = module.exports = {
+	  KEY:      META,
+	  NEED:     false,
+	  fastKey:  fastKey,
+	  getWeak:  getWeak,
+	  onFreeze: onFreeze
+	};
+
+/***/ },
+/* 65 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var global         = __webpack_require__(6)
+	  , core           = __webpack_require__(7)
+	  , LIBRARY        = __webpack_require__(46)
+	  , wksExt         = __webpack_require__(60)
+	  , defineProperty = __webpack_require__(11).f;
+	module.exports = function(name){
+	  var $Symbol = core.Symbol || (core.Symbol = LIBRARY ? {} : global.Symbol || {});
+	  if(name.charAt(0) != '_' && !(name in $Symbol))defineProperty($Symbol, name, {value: wksExt.f(name)});
+	};
+
+/***/ },
+/* 66 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var getKeys   = __webpack_require__(21)
+	  , toIObject = __webpack_require__(24);
+	module.exports = function(object, el){
+	  var O      = toIObject(object)
+	    , keys   = getKeys(O)
+	    , length = keys.length
+	    , index  = 0
+	    , key;
+	  while(length > index)if(O[key = keys[index++]] === el)return key;
+	};
+
+/***/ },
+/* 67 */
+/***/ function(module, exports, __webpack_require__) {
+
+	// all enumerable object keys, includes symbols
+	var getKeys = __webpack_require__(21)
+	  , gOPS    = __webpack_require__(68)
+	  , pIE     = __webpack_require__(69);
+	module.exports = function(it){
+	  var result     = getKeys(it)
+	    , getSymbols = gOPS.f;
+	  if(getSymbols){
+	    var symbols = getSymbols(it)
+	      , isEnum  = pIE.f
+	      , i       = 0
+	      , key;
+	    while(symbols.length > i)if(isEnum.call(it, key = symbols[i++]))result.push(key);
+	  } return result;
+	};
+
+/***/ },
+/* 68 */
+/***/ function(module, exports) {
+
+	exports.f = Object.getOwnPropertySymbols;
+
+/***/ },
+/* 69 */
+/***/ function(module, exports) {
+
+	exports.f = {}.propertyIsEnumerable;
+
+/***/ },
+/* 70 */
+/***/ function(module, exports, __webpack_require__) {
+
+	// 7.2.2 IsArray(argument)
+	var cof = __webpack_require__(26);
+	module.exports = Array.isArray || function isArray(arg){
+	  return cof(arg) == 'Array';
+	};
+
+/***/ },
+/* 71 */
+/***/ function(module, exports, __webpack_require__) {
+
+	// fallback for IE11 buggy Object.getOwnPropertyNames with iframe and window
+	var toIObject = __webpack_require__(24)
+	  , gOPN      = __webpack_require__(72).f
+	  , toString  = {}.toString;
+
+	var windowNames = typeof window == 'object' && window && Object.getOwnPropertyNames
+	  ? Object.getOwnPropertyNames(window) : [];
+
+	var getWindowNames = function(it){
+	  try {
+	    return gOPN(it);
+	  } catch(e){
+	    return windowNames.slice();
+	  }
+	};
+
+	module.exports.f = function getOwnPropertyNames(it){
+	  return windowNames && toString.call(it) == '[object Window]' ? getWindowNames(it) : gOPN(toIObject(it));
+	};
+
+
+/***/ },
+/* 72 */
+/***/ function(module, exports, __webpack_require__) {
+
+	// 19.1.2.7 / 15.2.3.4 Object.getOwnPropertyNames(O)
+	var $keys      = __webpack_require__(22)
+	  , hiddenKeys = __webpack_require__(35).concat('length', 'prototype');
+
+	exports.f = Object.getOwnPropertyNames || function getOwnPropertyNames(O){
+	  return $keys(O, hiddenKeys);
+	};
+
+/***/ },
+/* 73 */
+/***/ function(module, exports, __webpack_require__) {
+
+	var pIE            = __webpack_require__(69)
+	  , createDesc     = __webpack_require__(19)
+	  , toIObject      = __webpack_require__(24)
+	  , toPrimitive    = __webpack_require__(18)
+	  , has            = __webpack_require__(23)
+	  , IE8_DOM_DEFINE = __webpack_require__(14)
+	  , gOPD           = Object.getOwnPropertyDescriptor;
+
+	exports.f = __webpack_require__(15) ? gOPD : function getOwnPropertyDescriptor(O, P){
+	  O = toIObject(O);
+	  P = toPrimitive(P, true);
+	  if(IE8_DOM_DEFINE)try {
+	    return gOPD(O, P);
+	  } catch(e){ /* empty */ }
+	  if(has(O, P))return createDesc(!pIE.f.call(O, P), O[P]);
+	};
+
+/***/ },
+/* 74 */
+/***/ function(module, exports) {
+
+	
+
+/***/ },
+/* 75 */
+/***/ function(module, exports, __webpack_require__) {
+
+	__webpack_require__(65)('asyncIterator');
+
+/***/ },
+/* 76 */
+/***/ function(module, exports, __webpack_require__) {
+
+	__webpack_require__(65)('observable');
+
+/***/ },
+/* 77 */
 /***/ function(module, exports) {
 
 	'use strict';
@@ -1206,12 +2150,16 @@
 	            name = tokenName.call(this, name);
 
 	            localStorage.removeItem(name);
+	        },
+
+	        expiring: function expiring() {
+	            return false;
 	        }
 	    };
 	}();
 
 /***/ },
-/* 41 */
+/* 78 */
 /***/ function(module, exports) {
 
 	'use strict';
@@ -1241,10 +2189,10 @@
 	}();
 
 /***/ },
-/* 42 */
+/* 79 */
 /***/ function(module, exports) {
 
-	"use strict";
+	'use strict';
 
 	module.exports = {
 
@@ -1271,21 +2219,23 @@
 	    },
 
 	    _getHeaders: function _getHeaders(res) {
-	        return {
-	            token: res.headers[this.options.tokenHeader]
-	        };
+	        var i,
+	            data = {},
+	            headers = res.headers.map;
+
+	        for (i in headers) {
+	            data[i] = headers[i][0];
+	        }
+
+	        return data;
 	    },
 
 	    _setHeaders: function _setHeaders(req, headers) {
-	        if (headers.authorization) {
-	            req.headers[this.options.tokenHeader] = headers.authorization;
+	        var i;
+
+	        for (i in headers) {
+	            req.headers.set(i, headers[i]);
 	        }
-	    },
-
-	    _getQuery: function _getQuery() {
-	        // return this.$route.query.state
-
-	        return {};
 	    },
 
 	    _bindData: function _bindData(data, ctx) {
@@ -1295,6 +2245,8 @@
 
 	        error = data.error;
 	        success = data.success;
+
+	        data.query = ctx.$route.query || {};
 
 	        if (data.success) {
 	            data.success = function (res) {
@@ -1329,10 +2281,35 @@
 	    _beforeEach: function _beforeEach(routerBeforeEach, transitionEach) {
 	        var _this = this;
 
-	        this.options.router.beforeEach(function (transition) {
+	        this.options.router.beforeEach(function (transition, location, next) {
 	            routerBeforeEach.call(_this, function () {
-	                transitionEach.call(_this, transition.to.auth, function () {
-	                    transition.next();
+	                var auth;
+
+	                if (transition.to) {
+	                    auth = transition.to.auth;
+	                } else {
+	                    var authRoutes = transition.matched.filter(function (route) {
+	                        return route.meta.hasOwnProperty('auth');
+	                    });
+
+	                    // matches the nested route, the last one in the list
+	                    if (authRoutes.length) {
+	                        auth = authRoutes[authRoutes.length - 1].meta.auth;
+	                    }
+	                }
+
+	                transitionEach.call(_this, auth, function (redirect) {
+	                    if (!redirect) {
+	                        (next || transition.next)();
+	                        return;
+	                    }
+
+	                    // router v2.x
+	                    if (next) {
+	                        next(redirect);
+	                    } else {
+	                        this.options._routerReplace.call(this, redirect);
+	                    }
 	                });
 	            });
 	        });
@@ -1345,15 +2322,19 @@
 	    },
 
 	    _routerReplace: function _routerReplace(data) {
-	        this.options.router.replace(data);
+	        var router = this.options.router;
+
+	        router.replace.call(router, data);
 	    },
 
 	    _routerGo: function _routerGo(data) {
-	        this.options.router.go(data);
+	        var router = this.options.router;
+
+	        (router.push || router.go).call(router, data);
 	    },
 
 	    _httpData: function _httpData(res) {
-	        return res.json();
+	        return res.data || {};
 	    },
 
 	    _http: function _http(data) {


### PR DESCRIPTION
Previously, user fetch request was happening after every login. This is a useful shortcut, but sometimes we don't need this functionality.

This commit adds support for turning off the automatic user fetch request after login and before each route change.

We can pass the `fetchData` option to control this behaviour.

```js

Vue.use(require('@websanova/vue-auth'), {
  notFoundRedirect: '/',
  rolesVar: 'user_permissions',
  fetchData: null
})

```

If you pass a falsy value for `fetchData`, automatic user fetching will not happen.

If you don't pass the `fetchData` option, the plugin will do the user fetching with default parameters.

If you pass a custom object for `fetchData`, the plugin will use that configuration when fetching the user. Make sure that you provide an config object that has `url` and `method` properties in this case.