### PR TITLE
only check for objects and not arrays

### DIFF
--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -41,7 +41,7 @@ module.exports = (function (){
     function compare(one, two) {
         var i, ii, key;
 
-        if (typeof one === 'object' && typeof two === 'object') {
+            if (Object.prototype.toString.call(one) === '[object Object]' && Object.prototype.toString.call(two) === '[object Object]') {
             for (key in one) {
                 if (compare(one[key], two[key])) {
                     return true;


### PR DESCRIPTION
Before this change it returned "true" for both arrays and objects, now it only supports objects.

This is not 100% tested and needs to be tested with all kind of different data. I needed this change to be able to run `$auth.check([1,2,3,4])` to make the function return true if a user has one of these role_id's.

related to https://github.com/websanova/vue-auth/issues/64