### PR TITLE
Fixed token refresh callback

### DIFF
--- a/src/auth.js
+++ b/src/auth.js
@@ -41,22 +41,23 @@ module.exports = function () {
 
     function _routerBeforeEach(cb) {
         if (this.options.refreshData.enabled && this.options.tokenExpired.call(this)) {
+            var _this = this;
             this.options.refreshPerform.call(this, {
                 success: function() {
-                    if (this.options.fetchData.enabled) {
-                        this.watch.authenticated = false
-                        this.options.fetchPerform.call(this, {success: cb, error: cb});
+                    if (_this.options.fetchData.enabled) {
+                        _this.watch.authenticated = false
+                        _this.options.fetchPerform.call(_this, {success: cb, error: cb});
                     } else {
-                        this.watch.authenticated = true;
-                        return cb.call(this);
+                        _this.watch.authenticated = true;
+                        return cb.call(_this);
                     }
                 },
                 error: function() {
-                    this.options.logoutProcess.call(this, null, {});
+                    _this.options.logoutProcess.call(_this, null, {});
 
-                    this.watch.loaded = true
+                    _this.watch.loaded = true
 
-                    return cb.call(this);
+                    return cb.call(_this);
                 }
           });
         } else {


### PR DESCRIPTION
Hi,
I've spotted 2 issues related to token refresh which I think I fixed in the following PR. I'm aware I can remove duplication but for now I just wanted to post it for initial review (to check if it's the right direction).

Basically I see 2 problems related to token refresh at the moment:

1. When token is refreshed and `fetchData` is disabled callback for `_routerBeforeEach` is never called - I believe it's the root of the problem in #87 issue.
2. When token needs to be refreshed, data fetching (if enabled) does not wait for the refresh request to complete. It results in sending request for data fetch with expired token.

I've fixed both problems here but I tested it only with my use case.
I've started using this library recently so please keep in mind I may not be familiar with all use cases that needs to be handled.