### PR TITLE
Decode html-encoded state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
   "licenses": "MIT, GPL",
   
   "dependencies": {
-    "@websanova/vue-auth": "2.6.0-beta"
+    "@websanova/vue-auth": "2.6.0-beta",
+    "he": "^1.1.1"
   },
   
   "devDependencies": {

--- a/src/auth.js
+++ b/src/auth.js
@@ -1,6 +1,7 @@
 var __utils  = require('./lib/utils.js'),
     __token  = require('./lib/token.js'),
-    __cookie = require('./lib/cookie.js')
+    __cookie = require('./lib/cookie.js'),
+    he       = require('he');
 
 module.exports = function () {
 
@@ -316,7 +317,8 @@ module.exports = function () {
 
             try {
                 if (data.query.state) {
-                    state = JSON.parse(decodeURIComponent(data.query.state));
+                    var stateString = he.decode(decodeURIComponent(data.query.state));
+                    state = JSON.parse(stateString);
                 }
             }
             catch (e) {


### PR DESCRIPTION
I found that some OAuth2 providers send HTML encoded state that was not parsed with current code.
HTML encoding\decoding seems to be not a trivial solution.
I used tiny `he` lib to decode such state, it is supported by all browsers.