### PR TITLE
updating devise auth

### DIFF
--- a/drivers/auth/devise.js
+++ b/drivers/auth/devise.js
@@ -1,11 +1,11 @@
 module.exports = {
-    tokens: ['Token-Type', 'Access-Token', 'Client', 'Uid', 'Expiry'],
+    tokens: ['token-type', 'access-token', 'client', 'uid', 'expiry'],
 
     request: function (req, token) {
         var headers = {},
             tokens = token.split(';');
 
-        this.options.deviseAuth.tokens.forEach(function (tokenName, index) {
+        this.options.auth.tokens.forEach(function (tokenName, index) {
             if (tokens[index]) {
                 headers[tokenName] = tokens[index];
             }
@@ -18,8 +18,8 @@ module.exports = {
         var token = [],
             headers = this.options.http._getHeaders.call(this, res);
         
-        if (headers['Access-Token']) {
-            this.options.deviseAuth.tokens.forEach(function (tokenName) {
+        if (headers['access-token']) {
+            this.options.auth.tokens.forEach(function (tokenName) {
                 if (headers[tokenName]) {
                     token.push(headers[tokenName]);
                 }

--- a/drivers/auth/devise.js
+++ b/drivers/auth/devise.js
@@ -1,5 +1,6 @@
 module.exports = {
-    tokens: ['token-type', 'access-token', 'client', 'uid', 'expiry'],
+    tokens: ['Token-Type', 'Access-Token', 'Client', 'Uid', 'Expiry',
+        'token-type', 'access-token', 'client', 'uid', 'expiry'],
 
     request: function (req, token) {
         var headers = {},
@@ -18,8 +19,9 @@ module.exports = {
         var token = [],
             headers = this.options.http._getHeaders.call(this, res);
         
-        if (headers['access-token']) {
-            this.options.auth.tokens.forEach(function (tokenName) {
+        if (headers['access-token'] || headers['Access-Token']) {
+            var auth =  this.options.deviseAuth || this.options.auth;
+            auth.tokens.forEach(function (tokenName) {
                 if (headers[tokenName]) {
                     token.push(headers[tokenName]);
                 }

--- a/drivers/auth/devise.js
+++ b/drivers/auth/devise.js
@@ -6,7 +6,8 @@ module.exports = {
         var headers = {},
             tokens = token.split(';');
 
-        this.options.auth.tokens.forEach(function (tokenName, index) {
+        var auth =  this.options.deviseAuth || this.options.auth;
+        auth.tokens.forEach(function (tokenName, index) {
             if (tokens[index]) {
                 headers[tokenName] = tokens[index];
             }


### PR DESCRIPTION
Devise seems to be using lower cased headers now. I have changed the names to conform to this. 

Also, the recommended way of setting auth option was casing `this.options.deviseAuth` to be undefined. However, if `this.options.auth.tokens` is used, everything seems to work properly.