### PR TITLE
axios driver interceptor fix

### DIFF
--- a/drivers/http/axios.1.x.js
+++ b/drivers/http/axios.1.x.js
@@ -12,6 +12,8 @@ module.exports = {
       this.options.Vue.axios.interceptors.request.use(function (request) {
         req.call(_this, request);
         return request;
+      }, function (error) {
+        return Promise.reject(error);
       })
     }
 
@@ -19,6 +21,8 @@ module.exports = {
       this.options.Vue.axios.interceptors.response.use(function (response) {
         res.call(_this, response);
         return response;
+      }, function (error) {
+        return Promise.reject(error);
       })
     }
   },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@websanova/vue-auth",
 
   "description": "Vue.js token based authentication plugin. Supports simple token based and Json Web Tokens (JWT) authentication.",
-  
+
   "keywords": ["vue", "vue.js", "jwt", "auth", "authentication", "plugin", "json", "web", "token"],
 
   "author": {
@@ -11,29 +11,29 @@
     "username": "websanova",
     "email": "rob@websanova.com"
   },
-  
+
   "main": "src/index.js",
-  
+
   "version": "2.11.0-beta",
-  
+
   "repository": {
     "type": "git",
     "url": "https://github.com/websanova/vue-auth"
   },
-  
+
   "licenses": "MIT, GPL",
-  
+
   "dependencies": {
-    
+
   },
-  
+
   "devDependencies": {
     "babel-core": "6.16.0",
     "babel-loader": "6.2.5",
     "babel-runtime": "6.9.2",
     "babel-plugin-transform-runtime": "6.12.0",
     "babel-preset-es2015": "6.16.0",
-    
+
     "vue-loader": "9.5.1",
 
     "vue-style-loader": "1.0.0",
@@ -41,18 +41,18 @@
     "style-loader": "0.13.1",
     "vue-html-loader": "1.2.3",
     "file-loader": "^0.8.4",
-    
+
     "webpack": "1.13.1",
     "webpack-dev-server": "1.16.1",
     "webpack-stream": "3.2.0",
     "copy-webpack-plugin": "3.0.1",
     "replace-webpack-plugin": "0.1.2",
-    
+
     "@websanova/vue-auth": "2.11.0-beta",
-    "axios": "0.15.3",
-    "vue-axios": "1.2.2"
+    "axios": "^0.16.1",
+    "vue-axios": "^2.0.2"
   },
-  
+
   "scripts": {
     "1.x.demo": "webpack-dev-server --host=0.0.0.0 --https --port=8001 --content-base=1.x.demo/public/ --config=1.x.demo/webpack.config.js",
     "2.x.demo": "webpack-dev-server --host=0.0.0.0 --https --port=8002 --content-base=2.x.demo/public/ --config=2.x.demo/webpack.config.js"


### PR DESCRIPTION
If I update the axios driver to the latest (0.16.1) verison, the package unfortunately crashed. When I logged in and refresh the page, the application loses the authenticated user. Furthermore I can't process another HTTP request after login.

The problem seems to be caused by the newer axios driver interceptor is using two parameter instead of one.
The second parameter called, when the request/response isn't successfull.

I just simply add the function you can see below, as a 2nd parameter and its works fine for me.
```
this.options.Vue.axios.interceptors.response.use(
    success function here(),
    function (error) {
      return Promise.reject(error)
    }
```

I also test the changes in 1.x.demo and 2.x.demo and didn't get any error or problem.
