### PR TITLE
Add a default Http error handler

### DIFF
--- a/drivers/http/axios.1.x.js
+++ b/drivers/http/axios.1.x.js
@@ -38,7 +38,11 @@ module.exports = {
   },
 
   _http: function (data) {
-    this.options.Vue.axios(data).then(data.success, data.error);
+    if (data.error) {
+        this.options.Vue.axios(data).then(data.success, data.error);
+    } else {
+        this.options.Vue.axios(data).then(data.success, this.options.defaultHttpErrorHandler);
+    }
   },
 
   _getHeaders: function (res) {

--- a/drivers/http/vue-resource.1.x.js
+++ b/drivers/http/vue-resource.1.x.js
@@ -29,7 +29,11 @@ module.exports = {
     },
 
     _http: function (data) {
-        this.options.Vue.http(data).then(data.success, data.error);
+        if (data.error) {
+            this.options.Vue.http(data).then(data.success, data.error);
+        } else {
+            this.options.Vue.http(data).then(data.success, this.options.defaultHttpErrorHandler);
+        }
     },
 
     _getHeaders: function (res) {

--- a/src/auth.js
+++ b/src/auth.js
@@ -451,7 +451,11 @@ module.exports = function () {
         logoutOtherPerform: _logoutOtherPerform,
         logoutOtherProcess: _logoutOtherProcess,
 
-        oauth2Perform:      _oauth2Perform
+        oauth2Perform:      _oauth2Perform,
+
+        defaultHttpErrorHandler: function _defaultHttpErrorHandler(err) {
+            console.error(err)
+        }
     };
 
     function Auth(Vue, options) {


### PR DESCRIPTION
When we got a bad request from some internal request (such as refreshToken , fetchUser), a Uncaught (in promise) error will occurred.So we should set a default Http error handler to prevent this failure.