### PR TITLE
Check if Devise access-token more recent than last one

### DIFF
--- a/drivers/auth/devise.js
+++ b/drivers/auth/devise.js
@@ -28,7 +28,10 @@ module.exports = {
                 }
             });
             
-            return token.join(';');
+            // Check if access-token more recent than last one
+            if (!this.token() || parseInt(token[4], 10) >= parseInt(this.token().split(';')[4], 10)) {
+                return token.join(';');
+            }
         }
     }
 };


### PR DESCRIPTION
Sometimes, if multiple requests are issued at once, responses come in in different order than they were sent. A response's expiry token may then be earlier than an earlier received on. The Devise docs state that the token with the latest expiry date should be remembered.