### PR TITLE
Fixed IE/Edge localhost domain issue in cookie.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 demos/ssr.old
+.idea/

--- a/src/lib/cookie.js
+++ b/src/lib/cookie.js
@@ -3,8 +3,12 @@ module.exports = (function () {
     function setCookie (name, value, timeOffset) {
         var domain = this.options.cookieDomain(),
             expires = (new Date((new Date()).getTime() + timeOffset)).toUTCString();
+        if (domain === 'localhost'){
+            document.cookie = name + '=' + value + '; Expires=' + expires + ';';
+        } else {
+            document.cookie = name + '=' + value + '; Expires=' + expires + '; Path=/; Domain=' + domain + ';';
+        }
 
-        document.cookie = name + '=' + value + '; Expires=' + expires + '; Path=/; Domain=' + domain + ';';
     }
 
     return {


### PR DESCRIPTION
There is probably a better way to do this where you can use a regex to see if the domain is compatible with IE/Edge  sub.domain.com verse localhost or xxx.xxx.xxx.
