### PR TITLE
add license information to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
 
   "version": "2.21.14-beta",
 
+  "license": "MIT",
+
   "repository": {
     "type": "git",
     "url": "https://github.com/websanova/vue-auth"


### PR DESCRIPTION
for getting rid of this message:

`license-webpack-plugin: could not find any license type for @websanova/vue-auth in its package.json`

thanks for your work! :)