### PR TITLE
Allow functions for redirect config

### DIFF
--- a/docs/Privileges.md
+++ b/docs/Privileges.md
@@ -56,6 +56,28 @@ Typically used to hide pages while logged in. For instance we don't want the use
 
 So accessing it will be as if it's not there, hence a `404 Not Found`.
 
+### Redirect callbacks
+
+All redirects can also accept a callback which is passed the transition object.
+One use case for this is transitioning to a catch-all error route. For example:
+
+```js
+forbiddenRedirect: transition => ({
+    name: 'httpError',
+    params: [transition.path],
+}),
+```
+
+Which is defined in `router.js` as:
+
+```js
+{
+  path: '*',
+  name: 'httpError',
+  component: () =>
+    import(/* webpackChunkName: 'httpError' */ './views/HttpError'),
+},
+```
 
 ## Route Redirects
 

--- a/src/auth.js
+++ b/src/auth.js
@@ -92,10 +92,18 @@ module.exports = function () {
         if (routeAuth && (routeAuth === true || routeAuth.constructor === Array || __utils.isObject(routeAuth))) {
             if ( ! this.check()) {
                 __transitionRedirectType = 401;
+
+                if (typeof authRedirect === 'function') {
+                    authRedirect = authRedirect(transition);
+                }
                 cb.call(this, authRedirect);
             }
             else if ((routeAuth.constructor === Array || __utils.isObject(routeAuth)) && ! __utils.compare(routeAuth, this.watch.data[this.options.rolesVar])) {
                 __transitionRedirectType = 403;
+
+                if (typeof forbiddenRedirect === 'function') {
+                    forbiddenRedirect = forbiddenRedirect(transition);
+                }
                 cb.call(this, forbiddenRedirect);
             }
             else {
@@ -107,6 +115,10 @@ module.exports = function () {
         }
         else if (routeAuth === false && this.check()) {
             __transitionRedirectType = 404;
+
+            if (typeof notFoundRedirect === 'function') {
+                notFoundRedirect = notFoundRedirect(transition);
+            }
             cb.call(this, notFoundRedirect);
         }
         else {
@@ -128,7 +140,7 @@ module.exports = function () {
         if (req.impersonating === false && this.impersonating()) {
             tokenName = this.options.tokenDefaultName;
         }
-        
+
         token = __token.get.call(this, tokenName);
 
         if (token) {
@@ -273,7 +285,7 @@ module.exports = function () {
     function _fetchProcess(res, data) {
         this.watch.authenticated = true;
         this.watch.data = this.options.parseUserData.call(this, this.options.http._httpData.call(this, res));
-        
+
         this.watch.loaded = true;
 
         if (this.options.fetchData.success) { this.options.fetchData.success.call(this, res); }
@@ -702,7 +714,7 @@ module.exports = function () {
         if (this.impersonating()) {
             this.currentToken = this.options.tokenDefaultName;
         }
-    }; 
+    };
 
     return Auth;
 };

--- a/src/auth.js
+++ b/src/auth.js
@@ -257,6 +257,10 @@ module.exports = function () {
 
         if (auth) {
             redirect = auth.redirect || this.options.authRedirect;
+
+            if (typeof redirect === 'function') {
+                redirect = redirect(transition);
+            }
         }
 
         this.options.logoutProcess.call(this, res, {redirect: redirect});


### PR DESCRIPTION
Our app has a generic http route which allows us to show http errors without changing the URL. We'd prefer not to use specific `/403` and `/404` routes but we aren't able to use our httpError route with this library unless it exposes the transition object.