### PR TITLE
Bugfix to allow overridding checkAuthenticated

### DIFF
--- a/src/auth.js
+++ b/src/auth.js
@@ -79,7 +79,7 @@ module.exports = function () {
             return;
         }
 
-        _checkAuthenticated.call(this, cb);
+        this.options.checkAuthenticated.call(this, cb);
     }
 
     function _transitionEach(transition, routeAuth, cb) {


### PR DESCRIPTION
When refresh is disabled and checkAuthenticated is overridden using options, the default _checkAuthenticated method is called from _routerBeforeEach instead of the version defined in options.

This pull request is meant to fix that issue.