### PR TITLE
Fix tokenExpired

### DIFF
--- a/src/auth.js
+++ b/src/auth.js
@@ -69,7 +69,7 @@ module.exports = function () {
             this.options.logoutProcess.call(this, null, {});
         }
 
-        if (this.options.refreshData.enabled && ! this.watch.loaded && __token.get.call(this)) {
+        if (this.options.refreshData.enabled && ! this.watch.loaded && __token.get.call(this) && !this.options.tokenExpired.call(this)) {
             this.options.refreshPerform.call(this, {
                 success: function () {
                     this.options.checkAuthenticated.call(_this, cb);


### PR DESCRIPTION
When refresh is enabled and tokenExpired is overridden, vue auth still always refreshes on initial load.
The documentation mentions that overriding tokenExpired should be able to prevent that behaviour.

This pull request actually makes the code line up with the documentation.

This fixes issue #505 