### PR TITLE
Extend PluginObject and fix type of Redirect

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,4 +1,5 @@
 import {Vue} from 'vue/types/vue';
+import {PluginObject} from 'vue/types';
 
 //
 
@@ -52,23 +53,23 @@ interface LogoutOptions extends RequestOptions {
 interface Oauth2Options extends RequestOptions {
     code?: boolean;
     provider: string;
-    redirect?: redirect;
+    redirect?: Redirect;
     staySignedIn?: boolean;
     remember?: string;
 }
 
 interface ImpersonateOptions extends RequestOptions {
-    redirect?: redirect;
+    redirect?: Redirect;
 }
 
 interface UnimpersonateOptions extends RequestOptions {
-      redirect?: redirect;
+      redirect?: Redirect;
       makeRequest?: boolean;
 }
 
 //
 
-interface VueAuth {
+interface VueAuth extends PluginObject<any> {
 
     /**
      * Returns binded boolean property to know when auth is fully loaded.


### PR DESCRIPTION
To be installable with `Vue.use` the passed object must implement `PluginObject`, i. e. have the `install` function. 

Additionally there were some typos in the `redirect` type being lowercased.

A simple test is to create a `test.js` file and pass that through the typescript compiler:

```typescript
import VueAuth from '@websanova/vue-auth'
import Vue from 'vue'

Vue.use(VueAuth, {})
```

```bash
tsc test.ts
```