### PR TITLE
Vue 3 compat quick fix

### DIFF
--- a/src/auth.js
+++ b/src/auth.js
@@ -372,18 +372,24 @@ function _processRedirect(redirect) {
 }
 
 function _initVm() {
-    __auth.$vm = new __auth.Vue({
-        data: function () {
-            return {
-                data: null,
-                loaded: false,
-                redirect: null,
-                authenticated: null, // TODO: false ?
-                impersonating: undefined,
-                remember: undefined,
-            };
-        }
-    });
+    var vmData = {
+        data: null,
+        loaded: false,
+        redirect: null,
+        authenticated: null, // TODO: false ?
+        impersonating: undefined,
+        remember: undefined,
+    };
+    try {
+        var { reactive } = require('vue');
+        __auth.$vm = reactive(vmData)
+    } catch (e) {
+        __auth.$vm = new __auth.Vue({
+            data: function () {
+                return vmData;
+            }
+        });
+    }
 }
 
 function _initDriverCheck() {

--- a/src/index.js
+++ b/src/index.js
@@ -3,13 +3,17 @@ import Auth from './auth.js';
 function plugin(Vue, options) {
     Vue.auth = new Auth(Vue, options);
 
-    Object.defineProperties(Vue.prototype, {
-        $auth: {
-            get: function () {
-                return Vue.auth;
+    try {
+        Vue.config.globalProperties.$auth = Vue.auth;
+    } catch (e) {
+        Object.defineProperties(Vue.prototype, {
+            $auth: {
+                get: function () {
+                    return Vue.auth;
+                }
             }
-        }
-    });
+        });
+    }
 }
 
 if (typeof window !== 'undefined' && window.Vue) {


### PR DESCRIPTION
Allow use vue-auth with vue 3

You should init it like 
```js
import { createApp } from 'vue'
import axios from 'axios'
import VueAuth from '@websanova/vue-auth'
import authHttp from '@websanova/vue-auth/drivers/http/axios.1.x.js'
import authRouter from '@websanova/vue-auth/drivers/router/vue-router.2.x.js'

import App from './App.vue'
import router from './router'

const authOptions = {
  http: authHttp,
  router: authRouter,
  // other options...
}

const app = createApp(App).use(router)
app.axios = axios
app.router = router
app.use(VueAuth, authOptions)
```

Related to https://github.com/websanova/vue-auth/issues/606

It is dirty quick fix, and maybe there is need some `createAuth` export function as other plugins for vue 3 do (vuex, vue-router etc)