### PR TITLE
Fix redirect on invalid token request

### DIFF
--- a/src/auth.js
+++ b/src/auth.js
@@ -226,7 +226,7 @@ function _processInvalidToken(res, transition) {
         redirect = auth.redirect || __auth.options.authRedirect;
     }
 
-    _processLogout({redirect: redirect});
+    _processLogout(redirect);
 }
 
 function _processRouterBeforeEach(cb) {


### PR DESCRIPTION
Currently redirect to "login" route does not perform on "invalid token request" as invalid object passed to router (`{redirect: {path: '/login'}}` with default options). 
Actual redirect is performing on next route change now (as token cleared).