### PR TITLE
Fix unauth routes on token expire

### DIFF
--- a/src/auth.js
+++ b/src/auth.js
@@ -234,6 +234,8 @@ function _processRouterBeforeEach(cb) {
             .refresh()
             .then(function() {
                 _processAuthenticated(cb);
+            }, function() {
+                _processAuthenticated(cb);
             });
 
         return;


### PR DESCRIPTION
Currently if you have route without `meta.auth` (actually without redirect), you will see blank white page on first load if token expired (server return 401) as `refresh` failed and callback with router `next` will never be called in `beforeEach`