### PR TITLE
Do not clear redirect state if no actual redirect

### DIFF
--- a/src/auth.js
+++ b/src/auth.js
@@ -292,8 +292,10 @@ function _processTransitionEach(transition, routeAuth, cb) {
             cb.call(__auth, forbiddenRedirect);
         }
         else {
-            __auth.$vm.state.redirect = __auth.transitionRedirectType ? {type: __auth.transitionRedirectType, from: __auth.transitionPrev, to: __auth.transitionThis} : null;
-            __auth.transitionRedirectType = null;
+            if ((__auth.transitionPrev || {}).path !== __auth.transitionThis.path) {
+                __auth.$vm.state.redirect = __auth.transitionRedirectType ? {type: __auth.transitionRedirectType, from: __auth.transitionPrev, to: __auth.transitionThis} : null;
+                __auth.transitionRedirectType = null;
+            }
 
             return cb();
         }
@@ -308,8 +310,10 @@ function _processTransitionEach(transition, routeAuth, cb) {
         cb.call(__auth, notFoundRedirect);
     }
     else {
-        __auth.$vm.state.redirect = __auth.transitionRedirectType ? {type: __auth.transitionRedirectType, from: __auth.transitionPrev, to: __auth.transitionThis} : null;
-        __auth.transitionRedirectType = null;
+        if ((__auth.transitionPrev || {}).path !== __auth.transitionThis.path) {
+            __auth.$vm.state.redirect = __auth.transitionRedirectType ? {type: __auth.transitionRedirectType, from: __auth.transitionPrev, to: __auth.transitionThis} : null;
+            __auth.transitionRedirectType = null;
+        }
 
         return cb();
     }


### PR DESCRIPTION
If you open/refresh protected page with expired token (server return 401 on refresh user) there will be two redirects to auth page - one from http interceptor `_processLogout` (with default `invalidToken` method) and another from `_processTransitionEach` 401 handler. 
Because of this redirect state will be cleared on second redirect and you can not return to protected page after login.