### PR TITLE
fix: license annotation in package.json with SPDX license expression syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
         "type": "git",
         "url": "https://github.com/websanova/vue-auth"
     },
-    "licenses": "MIT, GPL",
+    "license": "(MIT OR GPL)",
     "scripts": {
         "clear": "rm -rf dist/*",
         "build": "npm run clear; node build/build.js",


### PR DESCRIPTION
Hello,
Use the SPDX license expression syntax version 2.0 string https://docs.npmjs.com/cli/v8/configuring-npm/package-json#license for multiple licence usage.

(fixing vscode & some other IDE warning).