### PR TITLE
Reset impersonating state on process logout

### DIFF
--- a/src/auth.js
+++ b/src/auth.js
@@ -338,6 +338,7 @@ function _processLogout(redirect) {
 
     __auth.$vm.state.loaded = true;
     __auth.$vm.state.authenticated = false;
+    __auth.$vm.state.impersonating = undefined;
     __auth.$vm.state.data = null;
 
     _processRedirect(redirect);


### PR DESCRIPTION
Currently, if you have expired impersonate token and you get 401 server response for refresh user you'll stuck in semi-impersonating mode. E.g. if you enter any valid credentials without refreshing page, token will be saved in `tokenImpersonateKey`. So you are become impersonating yourself without default token. Return to normal state avail after `unimpersonate` (which work like logout now) and relogin.